### PR TITLE
payloadBck variable not declared in alternate flow

### DIFF
--- a/response-caching-policy/response-caching-policy.xml
+++ b/response-caching-policy/response-caching-policy.xml
@@ -78,7 +78,7 @@
 			<mule:expression-component><![CDATA[										
 										app.registry['lock'].lock();
 										if (!app.registry['sn'].contains(key))
-											app.registry['sn'].store(key, payloadBck);
+											app.registry['sn'].store(key, payload);
 										app.registry['lock'].unlock();										
 										]]>
 			</mule:expression-component>				


### PR DESCRIPTION
change payloadBck to be payload when it is serialisable to avoid undeclared variable